### PR TITLE
Firestoreの変更をリアルタイムに検知できるようにreact-firebase-hooks導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-dropzone": "^11.0.1",
+    "react-firebase-hooks": "^2.2.0",
     "react-flatpickr": "^3.10.4",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",

--- a/src/components/templates/TeamListTemplate/index.tsx
+++ b/src/components/templates/TeamListTemplate/index.tsx
@@ -8,7 +8,7 @@ export const TeamListTemplate: React.FC<Props> = ({ teams }) => {
     <>
       <h3>TeamList</h3>
       {teams.map((team) => {
-        return <div>{team.name}</div>
+        return <div key={team.id}>{team.name}</div>
       })}
     </>
   )

--- a/src/pages/TeamList/index.tsx
+++ b/src/pages/TeamList/index.tsx
@@ -1,35 +1,36 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
+import { useCollection } from 'react-firebase-hooks/firestore'
 
 import { TeamListTemplate } from '../../components/templates/TeamListTemplate'
-import { db } from '../../services/Firebase'
+import firebase from '../../services/Firebase'
 
 export const TeamList: React.FC = () => {
-  const initTeams = [{ id: '', name: '' }]
-  const [teams, setTeams] = useState(initTeams)
-  useEffect(() => {
-    fetchTeams().then((docs) => {
-      if (docs) {
-        const result = docs.map((doc) => {
-          return {
-            id: doc.id,
-            name: doc.name,
-          }
-        })
-        setTeams(result)
-      }
-    })
-  }, [])
+  const [value, loading, error] = useCollection(
+    firebase.firestore().collection('teams'),
+    {
+      snapshotListenOptions: { includeMetadataChanges: true },
+    }
+  )
 
-  async function fetchTeams() {
-    const collectionRef = db.collection('teams')
-    const snapshots = await collectionRef.get()
-    const docs = snapshots.docs.map((doc) => doc.data())
-    return docs
+  if (loading) {
+    return <div>Loading...</div>
+  }
+  if (error && !value) {
+    return <div>Error:</div>
   }
 
   return (
     <>
-      <TeamListTemplate teams={teams} />
+      {value && (
+        <TeamListTemplate
+          teams={value.docs.map((doc) => {
+            return {
+              id: doc.id,
+              name: doc.data().name,
+            }
+          })}
+        />
+      )}
     </>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12734,6 +12734,11 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
+react-firebase-hooks@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-firebase-hooks/-/react-firebase-hooks-2.2.0.tgz#a2cea46d3da94619e8a316b85173638698ef7d2b"
+  integrity sha512-bwBaCYa8M+bpTqD0masAPGDTzxiTkGbyxv363hyR+NeNH1HbezPll6G7aMIGl+7OOYRPzfdmpkk72zc3VgXfEw==
+
 react-flatpickr@^3.10.4:
   version "3.10.6"
   resolved "https://registry.yarnpkg.com/react-flatpickr/-/react-flatpickr-3.10.6.tgz#d6fe73ee12d13f2a804e5362c82e2688b6fbd409"


### PR DESCRIPTION
## このPRについて

最初に実装したロジックだと、Firestore側のドキュメントが変更されても、React側の方では画面再読み込みをしない限り更新されないのでFirestoreらしい機能が導入されてなかった

そのためreact-firebase-hooks導入して、Firestoreのドキュメント更新されたら自動的に画面側が反映されるように修正